### PR TITLE
fixed ContextErrorException

### DIFF
--- a/src/SignaledCommand.php
+++ b/src/SignaledCommand.php
@@ -29,8 +29,8 @@ abstract class SignaledCommand extends Command
     public static final function getDefaultStopSignals()
     {
         return [
-            SIGTERM,
-            SIGINT
+            'SIGTERM',
+            'SIGINT'
         ];
     }
 


### PR DESCRIPTION
fixed exception:
[Symfony\Component\Debug\Exception\ContextErrorException]
Notice: Use of undefined constant SIGTERM - assumed 'SIGTERM'
- Some SIGNALS constants are not supported in all PHP versions
- and will conditionally be translated from strings to constants
